### PR TITLE
fix/ci

### DIFF
--- a/.github/workflows/proof_verification_tests.yml
+++ b/.github/workflows/proof_verification_tests.yml
@@ -9,11 +9,11 @@ on:
       - main
 
 jobs:
-  verify-proof-cairo0:
+  verify-example-proofs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cairo_version: ["cairo0"]
+        cairo_version: ["cairo0", "cairo1"]
         layout: ["dex", "recursive", "recursive_with_poseidon", "small", "starknet", "starknet_with_keccak"]
     steps:
       - name: Checkout repository
@@ -43,41 +43,3 @@ jobs:
       
       - name: Run verification
         run: cargo run --release --bin runner -- -p target/dev/cairo_verifier.sierra.json -c ${{ matrix.cairo_version }} < examples/proofs/${{ matrix.layout }}/${{ matrix.cairo_version }}_example_proof.json
-
-  verify-proof-cairo1:
-      runs-on: ubuntu-latest
-      strategy:
-        matrix:
-          cairo_version: ["cairo1"]
-          layout: ["dex", "recursive", "recursive_with_poseidon", "small", "starknet", "starknet_with_keccak"]
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v3
-        
-        - name: Setup Scarb
-          uses: software-mansion/setup-scarb@v1
-        
-        - name: Setup Rust toolchain
-          uses: actions-rust-lang/setup-rust-toolchain@v1
-        
-        - name: Setup Python
-          uses: actions/setup-python@v2
-          with:
-            python-version: '3.10'
-        
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
-        
-        - name: Configure layout
-          run: python configure.py -l ${{ matrix.layout }} -s keccak
-        
-        - name: Build project
-          run: scarb build
-        
-        - name: Test project
-          run: scarb test
-        
-        - name: Run verification
-          run: cargo run --release --bin runner -- -p target/dev/cairo_verifier.sierra.json -c ${{ matrix.cairo_version }} < examples/proofs/${{ matrix.layout }}/${{ matrix.cairo_version }}_example_proof.json

--- a/.github/workflows/proof_verification_tests.yml
+++ b/.github/workflows/proof_verification_tests.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Build project
         run: scarb build
       
-      - name: Test project
-        run: scarb test
-      
       - name: Run verification
         run: cargo run --release --bin runner -- -p target/dev/cairo_verifier.sierra.json -c ${{ matrix.cairo_version }} < examples/proofs/${{ matrix.layout }}/${{ matrix.cairo_version }}_example_proof.json
 


### PR DESCRIPTION
[This](https://github.com/HerodotusDev/integrity/blob/8a0899f878b775e5d1ab252480f946a645916a65/src/lib.cairo#L17-L19) part of the code includes test only when `recursive` layout is on. CI was running tests after configure step that failed in most cases because it changed layout and then tried to test resulting in test dependencies not found