### PR TITLE
Remove deprecated `sncast` command arg

### DIFF
--- a/verify-on-starknet.sh
+++ b/verify-on-starknet.sh
@@ -40,4 +40,3 @@ sncast \
     --contract-address "$contract_address" \
     --function "verify_proof_full_and_register_fact" \
     --calldata $layout $hasher $stone_version $memory_verification $calldata \
-    --fee-token eth


### PR DESCRIPTION
The `./verify-on-starknet.sh` script fails on sncast v0.35.0 and above

`--fee-token` was deprecated here: https://github.com/foundry-rs/starknet-foundry/blob/21afb8b42b84cb4bf8eba5b740c7530797c0db4c/CHANGELOG.md?plain=1#L118